### PR TITLE
Fix argument parsing of `llamacpp-cli` and `llamacpp-chat` tools

### DIFF
--- a/src/llamacpp/chat.py
+++ b/src/llamacpp/chat.py
@@ -99,6 +99,9 @@ def parse_chat_params(argv) -> Dict[str, str]:
 
 def run():
     args = parse_chat_params(sys.argv)
+
+    args.instruct = False
+
     return llamacpp_main(args)
 
 

--- a/src/llamacpp/chat.py
+++ b/src/llamacpp/chat.py
@@ -2,6 +2,7 @@
 import sys
 import llamacpp
 import argparse
+from typing import Dict
 
 from llamacpp.cli import main as llamacpp_main
 
@@ -13,7 +14,7 @@ Bob: Hello. How may I help you today?
 User:"""
 
 
-def parse_chat_params(argv) -> llamacpp.gpt_params:
+def parse_chat_params(argv) -> Dict[str, str]:
     """Parse chat parameters"""
 
     parser = argparse.ArgumentParser(description="LLaMa")

--- a/src/llamacpp/chat.py
+++ b/src/llamacpp/chat.py
@@ -88,7 +88,6 @@ def parse_chat_params(argv) -> llamacpp.gpt_params:
         help="batch size for prompt processing (default: 2)",
     )
     parser.add_argument("-m", "--model", type=str, default="./models/7B/ggml-model-q4_0.bin", help="model path (default: )")
-    parser.usage = parser.format_help()
 
     args = parser.parse_args(argv[1:])
 

--- a/src/llamacpp/chat.py
+++ b/src/llamacpp/chat.py
@@ -90,6 +90,7 @@ def parse_chat_params(argv) -> Dict[str, str]:
     )
     parser.add_argument("-m", "--model", type=str, default="./models/7B/ggml-model-q4_0.bin", help="model path (default: )")
     parser.add_argument("--mlock", action="store_true", help="use mlock to lock memory")
+    parser.add_argument("--memory_f16", action="store_true", help="use half-precision memory")
 
     args = parser.parse_args(argv[1:])
 

--- a/src/llamacpp/chat.py
+++ b/src/llamacpp/chat.py
@@ -89,6 +89,7 @@ def parse_chat_params(argv) -> Dict[str, str]:
         help="batch size for prompt processing (default: 2)",
     )
     parser.add_argument("-m", "--model", type=str, default="./models/7B/ggml-model-q4_0.bin", help="model path (default: )")
+    parser.add_argument("--mlock", action="store_true", help="use mlock to lock memory")
 
     args = parser.parse_args(argv[1:])
 

--- a/src/llamacpp/cli.py
+++ b/src/llamacpp/cli.py
@@ -77,7 +77,7 @@ def parse_args_into_params(argv) -> Dict[str, str]:
         help="batch size for prompt processing (default: 8)",
     )
     parser.add_argument("-m", "--model", type=str, default="./models/7B/ggml-model-q4_0.bin", help="model path (default: )")
-    parser.add_argument("--use_mlock", action="store_true", help="use mlock to lock memory")
+    parser.add_argument("--mlock", action="store_true", help="use mlock to lock memory")
     parser.add_argument("--memory_f16", action="store_true", help="use half-precision memory")
 
     args = parser.parse_args(argv[1:])
@@ -119,7 +119,7 @@ def main(args):
     params.top_p = args.top_p
     params.temp = args.temp
     params.repeat_penalty = args.repeat_penalty
-    params.use_mlock = args.use_mlock
+    params.use_mlock = args.mlock
     params.memory_f16 = args.memory_f16
     params.n_ctx = args.n_ctx
 

--- a/src/llamacpp/cli.py
+++ b/src/llamacpp/cli.py
@@ -106,11 +106,6 @@ def process_interactive_input(model: llamacpp.LlamaInference):
 def main(args):
     """Main function"""
 
-    # if args.file is specified, read the file and set the prompt to the contents
-    if args.file:
-        with open(args.file, "r") as f:
-            args.prompt = f.read().strip()
-
     # Add a space in front of the first character to match OG llama tokenizer behavior
     args.prompt = " " + args.prompt
     
@@ -209,6 +204,12 @@ def main(args):
 def run():
     # Parse params into a gpt_params object
     args = parse_args_into_params(sys.argv)
+
+    # if args.file is specified, read the file and set the prompt to the contents
+    if args.file:
+        with open(args.file, "r") as f:
+            args.prompt = f.read().strip()
+
     return main(args)
 
 

--- a/src/llamacpp/cli.py
+++ b/src/llamacpp/cli.py
@@ -82,8 +82,6 @@ def parse_args_into_params(argv) -> Dict[str, str]:
     parser.add_argument("--n_batch", type=int, default=8, help="number of tokens per batch")
     parser.add_argument("--n_threads", type=int, default=4, help="number of threads to use")
 
-    parser.usage = parser.format_help()
-
     args = parser.parse_args(argv[1:])
 
     if args.interactive or args.instruct:

--- a/src/llamacpp/cli.py
+++ b/src/llamacpp/cli.py
@@ -74,12 +74,11 @@ def parse_args_into_params(argv) -> Dict[str, str]:
         "--batch_size",
         type=int,
         default=8,
-        help="batch size for prompt processing (default: 2)",
+        help="batch size for prompt processing (default: 8)",
     )
     parser.add_argument("-m", "--model", type=str, default="./models/7B/ggml-model-q4_0.bin", help="model path (default: )")
     parser.add_argument("--use_mlock", action="store_true", help="use mlock to lock memory")
     parser.add_argument("--memory_f16", action="store_true", help="use half-precision memory")
-    parser.add_argument("--n_batch", type=int, default=8, help="number of tokens per batch")
 
     args = parser.parse_args(argv[1:])
 
@@ -115,7 +114,7 @@ def main(args):
     params.n_threads = args.threads
 
     params.repeat_last_n = args.repeat_last_n
-    params.n_batch = args.n_batch
+    params.n_batch = args.batch_size
     params.top_k = args.top_k
     params.top_p = args.top_p
     params.temp = args.temp

--- a/src/llamacpp/cli.py
+++ b/src/llamacpp/cli.py
@@ -63,7 +63,7 @@ def parse_args_into_params(argv) -> Dict[str, str]:
     )
     parser.add_argument(
         "-c",
-        "--n_ctx",
+        "--ctx_size",
         type=int,
         default=512,
         help="size of the prompt context (default: 512)",
@@ -121,7 +121,7 @@ def main(args):
     params.repeat_penalty = args.repeat_penalty
     params.use_mlock = args.mlock
     params.memory_f16 = args.memory_f16
-    params.n_ctx = args.n_ctx
+    params.n_ctx = args.ctx_size
 
     model = llamacpp.LlamaInference(params)
     model.update_input([model.token_bos()])

--- a/src/llamacpp/cli.py
+++ b/src/llamacpp/cli.py
@@ -33,7 +33,7 @@ def parse_args_into_params(argv) -> Dict[str, str]:
         "--threads",
         type=int,
         default=4,
-        help="number of threads to use during computation (default: 1)",
+        help="number of threads to use during computation (default: 4)",
     )
     parser.add_argument(
         "-p",
@@ -80,7 +80,6 @@ def parse_args_into_params(argv) -> Dict[str, str]:
     parser.add_argument("--use_mlock", action="store_true", help="use mlock to lock memory")
     parser.add_argument("--memory_f16", action="store_true", help="use half-precision memory")
     parser.add_argument("--n_batch", type=int, default=8, help="number of tokens per batch")
-    parser.add_argument("--n_threads", type=int, default=4, help="number of threads to use")
 
     args = parser.parse_args(argv[1:])
 
@@ -118,7 +117,7 @@ def main(args):
     params = llamacpp.InferenceParams()
     params.path_model = args.model
     params.seed = args.seed
-    params.n_threads = args.n_threads
+    params.n_threads = args.threads
 
     params.repeat_last_n = args.repeat_last_n
     params.n_batch = args.n_batch


### PR DESCRIPTION
Several argument parsing inconsistencies prevented  `llamacpp-cli` from working as expected and `llamacpp-chat` from working at all.

Note that even with these fixes,  the tools don't work yet:
- `llamacpp-cli` outputs something, but not a completion of the prompt (I guess it lists the first token of several possible completions)
- `llamacpp-chat` crashes because `model.is_antiprompt_present()` does not exist (it exists in a different version of the bindings than is being installed)
