### PR TITLE
Create tests and improve LlamaContext example script

### DIFF
--- a/examples/simple_low_level.py
+++ b/examples/simple_low_level.py
@@ -1,6 +1,52 @@
+import array
 import llamacpp
 
 params = llamacpp.LlamaContextParams()
-model = llamacpp.LlamaContext("./models/7B/ggml-model-q4_0.bin", params)
+model = llamacpp.LlamaContext("./models/7B/ggml-model-f16.bin", params)
 
-print(model.get_n_embd())
+prompt = "Llama is"
+# add a space in front of the first character to match OG llama tokenizer behavior
+prompt = f" {prompt}"
+
+# tokenize the prompt
+embd_inp = model.str_to_token(prompt, True)
+
+n_ctx = model.get_n_ctx()
+
+if len(embd_inp) > n_ctx - 4:
+    raise Exception("Prompt is too long")
+
+n_past = 0
+n_remain = 9
+n_consumed = 0
+embd = []
+
+while n_remain:
+    if len(embd):
+        if model.eval(array.array('i', embd), len(embd), n_past, 1):
+            raise Exception("Failed to predict\n")
+    n_past += len(embd)
+    embd.clear()
+
+    if len(embd_inp) <= n_consumed:
+        # sample
+        top_k = 40
+        top_p = 0.95
+        temp = 0.8
+        repeat_last_n = 64
+
+        # sending an empty array for the last n tokens
+        id = model.sample_top_p_top_k(array.array('i', []), top_k, top_p, temp, repeat_last_n)
+        # add it to the context
+        embd.append(id)
+        # decrement remaining sampling budget
+        n_remain -= 1
+    else:
+        # has unconsumed input
+        while len(embd_inp) > n_consumed:
+            # update_input
+            embd.append(embd_inp[n_consumed])
+            n_consumed += 1
+
+    for id in embd:
+        print(model.token_to_str(id), end="")

--- a/tests/test_llama_context.py
+++ b/tests/test_llama_context.py
@@ -1,0 +1,25 @@
+import pytest
+import llamacpp
+
+
+@pytest.fixture(scope="session")
+def llama_context():
+    params = llamacpp.LlamaContextParams()
+    params.seed = 19472
+    return llamacpp.LlamaContext("../models/7B/ggml-model-f16.bin", params)
+
+
+def test_str_to_token(llama_context):
+    prompt = "Hello World"
+    prompt_tokens = llama_context.str_to_token(prompt, True)
+    assert prompt_tokens == [1, 10994, 2787]
+
+
+def test_token_to_str(llama_context):
+    tokens = [1, 10994, 2787]
+    text = ''.join([llama_context.token_to_str(token) for token in tokens])
+    assert text == "Hello World"
+
+
+def test_eval(llama_context):
+    pass

--- a/tests/test_llama_inference.py
+++ b/tests/test_llama_inference.py
@@ -1,0 +1,44 @@
+import pytest
+import llamacpp
+
+
+@pytest.fixture(scope="session")
+def llama_model():
+    params = llamacpp.InferenceParams()
+    params.path_model = '../models/7B/ggml-model-f16.bin'
+    params.seed = 19472
+    return llamacpp.LlamaInference(params)
+
+
+def test_update_input(llama_model):
+    prompt_tokens = [1, 2, 3]
+    llama_model.update_input(prompt_tokens)
+    assert llama_model.has_unconsumed_input()
+    llama_model.ingest_all_pending_input()
+    assert not llama_model.has_unconsumed_input()
+
+
+def test_tokenize(llama_model):
+    prompt = "Hello World"
+    prompt_tokens = llama_model.tokenize(prompt, True)
+    assert prompt_tokens == [1, 10994, 2787]
+
+
+def test_token_to_str(llama_model):
+    tokens = [1, 10994, 2787]
+    text = ''.join([llama_model.token_to_str(token) for token in tokens])
+    assert text == "Hello World"
+
+
+def test_eval(llama_model):
+    prompt = "Llama is"
+    prompt_tokens = llama_model.tokenize(prompt, True)
+    llama_model.update_input(prompt_tokens)
+    llama_model.ingest_all_pending_input()
+    output = prompt
+    for i in range(9):
+        llama_model.eval()
+        token = llama_model.sample()
+        output += llama_model.token_to_str(token)
+
+    assert output == "Llama is the newest member of our farm family."

--- a/tests/test_llama_inference.py
+++ b/tests/test_llama_inference.py
@@ -7,6 +7,10 @@ def llama_model():
     params = llamacpp.InferenceParams()
     params.path_model = '../models/7B/ggml-model-f16.bin'
     params.seed = 19472
+    params.top_k = 40
+    params.top_p = 0.95
+    params.repeat_last_n = 64
+    params.n_predict = 8
     return llamacpp.LlamaInference(params)
 
 
@@ -36,9 +40,9 @@ def test_eval(llama_model):
     llama_model.update_input(prompt_tokens)
     llama_model.ingest_all_pending_input()
     output = prompt
-    for i in range(9):
+    for i in range(8):
         llama_model.eval()
         token = llama_model.sample()
         output += llama_model.token_to_str(token)
 
-    assert output == "Llama is the newest member of our farm family."
+    assert output == " Llama is the newest member of our farm family"


### PR DESCRIPTION
After discussing the lack of regression tests in the codebase (see https://github.com/thomasantony/llamacpp-python/issues/9), I created two very simple tests suites:

- `test_llama_inference.py`: to test the LlamaInference object
- `test_llama_context.py`: to test the LlamaContext object

The whole idea is to set a seed in the params and check that we always get that result. Just for confirmation, here the output of the original llama.cpp that was used for both test: 

```shell
❯ ./main -s 19472 --prompt "Llama is" -m ./models/7B/ggml-model-f16.bin -n 8 --top_k 40 --top_p 0.95 --temp 0.8 --repeat_last_n 64
main: seed = 19472
llama_model_load: loading model from './models/7B/ggml-model-f16.bin' - please wait ...
llama_model_load: n_vocab = 32000
llama_model_load: n_ctx   = 512
llama_model_load: n_embd  = 4096
llama_model_load: n_mult  = 256
llama_model_load: n_head  = 32
llama_model_load: n_layer = 32
llama_model_load: n_rot   = 128
llama_model_load: f16     = 1
llama_model_load: n_ff    = 11008
llama_model_load: n_parts = 1
llama_model_load: type    = 1
llama_model_load: ggml map size = 12853.45 MB
llama_model_load: ggml ctx size =  81.25 KB
llama_model_load: mem required  = 14645.53 MB (+ 1026.00 MB per state)
llama_model_load: loading tensors from './models/7B/ggml-model-f16.bin'
llama_model_load: model size = 12853.02 MB / num tensors = 291
llama_init_from_file: kv self size  =  256.00 MB

system_info: n_threads = 4 / 10 | AVX = 0 | AVX2 = 0 | AVX512 = 0 | FMA = 0 | NEON = 1 | ARM_FMA = 1 | F16C = 0 | FP16_VA = 1 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 0 | VSX = 0 |
sampling: temp = 0.800000, top_k = 40, top_p = 0.950000, repeat_last_n = 64, repeat_penalty = 1.100000
generate: n_ctx = 512, n_batch = 8, n_predict = 8, n_keep = 0


 Llama is the newest member of our farm family
llama_print_timings:        load time =   887.44 ms
llama_print_timings:      sample time =     5.85 ms /     8 runs   (    0.73 ms per run)
llama_print_timings: prompt eval time =   705.16 ms /     5 tokens (  141.03 ms per token)
llama_print_timings:        eval time =   848.66 ms /     7 runs   (  121.24 ms per run)
llama_print_timings:       total time =  1742.07 ms
```

It also updates the simple low level script using the Llama Context object to have something that works in a very simple scenario based on the original main.cpp. 

Note that the tests currently fail because I did not get the same exact values as the original repository 😢. I was not able to find why yet but I think it is already an improvement. 