### PR TITLE
Fix sending of parameters like -c and -s to llama.cpp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "llama.cpp"]
 	path = vendor/llama.cpp
-	url = git@github.com:thomasantony/llama.cpp.git
+	url = https://github.com/thomasantony/llama.cpp

--- a/src/llama_wrapper.cpp
+++ b/src/llama_wrapper.cpp
@@ -25,6 +25,13 @@ bool LlamaWrapper::init()
     }else{
         inference_params.ctx_params.progress_callback = nullptr;
     }
+
+	// update default ctx params with our user-selected overrides
+	inference_params.ctx_params.n_ctx = inference_params.n_ctx;
+	inference_params.ctx_params.seed = inference_params.seed;
+	inference_params.ctx_params.use_mlock = inference_params.use_mlock;
+	inference_params.ctx_params.f16_kv = inference_params.memory_f16;
+
     ctx = llama_init_from_file(inference_params.path_model.c_str(), inference_params.ctx_params);
 
     n_ctx = llama_n_ctx(ctx);

--- a/src/llama_wrapper.cpp
+++ b/src/llama_wrapper.cpp
@@ -26,11 +26,11 @@ bool LlamaWrapper::init()
         inference_params.ctx_params.progress_callback = nullptr;
     }
 
-	// update default ctx params with our user-selected overrides
-	inference_params.ctx_params.n_ctx = inference_params.n_ctx;
-	inference_params.ctx_params.seed = inference_params.seed;
-	inference_params.ctx_params.use_mlock = inference_params.use_mlock;
-	inference_params.ctx_params.f16_kv = inference_params.memory_f16;
+    // update default ctx params with our user-selected overrides
+    inference_params.ctx_params.n_ctx = inference_params.n_ctx;
+    inference_params.ctx_params.seed = inference_params.seed;
+    inference_params.ctx_params.use_mlock = inference_params.use_mlock;
+    inference_params.ctx_params.f16_kv = inference_params.memory_f16;
 
     ctx = llama_init_from_file(inference_params.path_model.c_str(), inference_params.ctx_params);
 


### PR DESCRIPTION
This patch fixes a bug where user-set parameters -c (n_ctx) -s (seed), --mlock (use_mlock), and --memory_f16 (memory_f16) are not actually being sent to llama.cpp. inference_params.ctx_params in llama_wrapper.cpp was never updated with the user-set parameters.

From my testing this PR helps with issue https://github.com/thomasantony/llamacpp-python/issues/13 as I can successfully increase n_ctx to 2048 and handle over 1000 tokens. However the program will still segfault when the number of tokens is larger than n_ctx.